### PR TITLE
fix #1: Return event name instead of event object on payload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export const eventHandler = async (
   const uaParser = new UAParser(client.userAgent).getResult()
   /* eslint-disable  @typescript-eslint/no-explicit-any */
   const segmentPayload: any = {
-    ...(payload.event && { event }),
+    ...(payload.event && { event: payload.event }),
     callType: eventType,
     anonymousId: payload.anonymousId,
     userId: payload.userId,


### PR DESCRIPTION
This should fix the issue with the event name as per issue #1. Tested locally & using my test account. Reviewed other fields and can't find any similar issues. We should be good to go with the change now being as it was intended.