### PR TITLE
Use custom hostname if it's provided in payload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,13 @@ export const eventHandler = async (
 ) => {
   const { payload, client } = event
 
-  let { writeKey, hostname = 'api.segment.io' } = settings
+  let { hostname = 'api.segment.io' } = settings
   if (payload.hostname) {
     hostname = payload.hostname
   }
   const endpoint = `https://${hostname}/v1/${eventType}`
+
+  const { writeKey } = settings
 
   // Prepare new payload
   const uaParser = new UAParser(client.userAgent).getResult()

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,10 @@ export const eventHandler = async (
 ) => {
   const { payload, client } = event
 
-  const { writeKey, hostname = 'api.segment.io' } = settings
+  let { writeKey, hostname = 'api.segment.io' } = settings
+  if (payload.hostname) {
+    hostname = payload.hostname
+  }
   const endpoint = `https://${hostname}/v1/${eventType}`
 
   // Prepare new payload


### PR DESCRIPTION
Zaraz sets the defaultField as part of payload. Custom host is sent in payload, we need to take it into consideration. With this change, if `hostname` is present in payload, we use it instead of the default hostname